### PR TITLE
Make the fontsize of numbers in the meta diffviewer larger

### DIFF
--- a/src/components/diffviewermeta.js
+++ b/src/components/diffviewermeta.js
@@ -47,7 +47,9 @@ const NetCoverageContainer = ({ coverage, parsedDiff }) => {
 
 const NetCoverage = ({ addedLines, coveredLines, netGain }) => (
   <tr><td>
-    {`New lines coverage change: ${netGain}% / `}
+    <span className="net-lines-coverage-change">
+        New lines coverage change: {netGain}% /&nbsp;
+    </span>
     {`Added lines: ${addedLines} / `}
     {`Covered lines: ${coveredLines}`}
   </td></tr>

--- a/src/components/diffviewermeta.js
+++ b/src/components/diffviewermeta.js
@@ -48,9 +48,9 @@ const NetCoverageContainer = ({ coverage, parsedDiff }) => {
 const NetCoverage = ({ addedLines, coveredLines, netGain }) => (
   <tr><td>
     <span className="net-lines-coverage-change">
-        New lines coverage change: {netGain}% /&nbsp;
+        New lines coverage change: {netGain}%;
     </span>
-    {`Added lines: ${addedLines} / `}
+    {` / Added lines: ${addedLines} / `}
     {`Covered lines: ${coveredLines}`}
   </td></tr>
 );

--- a/src/style.css
+++ b/src/style.css
@@ -29,6 +29,10 @@ td.line_content, td.new_line_number, td.old_line_number {
 .diffblock {
 	width: 100%;
 }
+/* Diff viewer meta */
+.net-lines-coverage-change {
+	font-size: 150%;
+}
 /* Line coverage status*/
 .hit, .miss, .nocovchange {
 	width: 20px;


### PR DESCRIPTION
Hi Armen,
I made a change about the fontsize of the numbers in the meta diffviewer area,
now they are bigger, and easier to view. Would you take a look at it?
Linkai

<img width="532" alt="screen shot 2017-09-23 at 2 59 23 pm" src="https://user-images.githubusercontent.com/22087268/30776175-d8084afe-a06f-11e7-9cc6-98628e629a62.png">
